### PR TITLE
Output helpers

### DIFF
--- a/doc_parser.py
+++ b/doc_parser.py
@@ -103,6 +103,7 @@ class ParserCollection:
             ):
         self.parser = parser
         self.docs = {}
+        self._next_key = 0
         if type(files) == str: #Walk the directory.
             for (path, dirnames, filenames) in os.walk(files):
                 for filename in filenames:
@@ -123,7 +124,8 @@ class ParserCollection:
         Parameters:
           - filepath: The path to the file.
         """
-        self.docs[filepath] = self.parser(filepath)
+        self.docs[self._next_key] = self.parser(filepath)
+        self._next_key += 1
 
     def output_dicts(
             self,
@@ -141,8 +143,9 @@ class ParserCollection:
         """
         if not props:
             props = self.output_props
-        for doc in self.docs.values():
+        for key, doc in self.docs.items():
             output = {}
-            for prop in props:
+            output['key'] = getattr(doc, 'key', key) #Use the parser's key attr if it has it.
+            for prop in [p for p in props if p != 'key']:
                 output[prop] = getattr(doc, prop, None)
             yield output

--- a/doc_parser.py
+++ b/doc_parser.py
@@ -155,15 +155,21 @@ class ParserCollection:
         for key, doc in self.docs.items():
             key = getattr(doc, 'key', key) #Use the parser's key attr if it has it
             if not extended_attr: #Fetch doc attrs (non-extended mode)
-                output = {}
-                output['key'] = key
-                for prop in [p for p in props if p != 'key']:
-                    output[prop] = getattr(doc, prop, None)
-                yield output
-            else: #Fetch 0 or more records from a single doc attr (extended mode)
-                for record in getattr(doc, extended_attr, []): #Empty list default to prevent error
+                try:
                     output = {}
-                    output['doc_key'] = key
-                    for prop in [p for p in props if p != 'doc_key']:
-                        output[prop] = record[prop] if prop in record else None
+                    output['key'] = key
+                    for prop in [p for p in props if p != 'key']:
+                        output[prop] = getattr(doc, prop, None)
                     yield output
+                except:
+                    continue
+            else: #Fetch 0 or more records from a single doc attr (extended mode)
+                try:
+                    for record in getattr(doc, extended_attr, []): #Empty list default to prevent error
+                        output = {}
+                        output['doc_key'] = key
+                        for prop in [p for p in props if p != 'doc_key']:
+                            output[prop] = record[prop] if prop in record else None
+                        yield output
+                except:
+                    continue

--- a/doc_parser.py
+++ b/doc_parser.py
@@ -221,3 +221,29 @@ class ParserCollection:
                             yield output
                     except:
                         continue
+
+    def output_csv(
+            self,
+            filename: str,
+            **kwargs,
+            ) -> 'ParserCollection':
+        """
+        Creates a csv file based on output_dicts. See that method for additional
+        information on usage.
+
+        Parameters:
+          - filename: The filename for the csv (can be specified as just the
+            file basename, or with an absolute or relative path).
+          - **kwargs: Will be sent to output_data to generate the data for the
+            csv file. See that method for available options.
+        Return: self, for the purposes of chaining multiple outputs together.
+        """
+        try:
+            with open(filename, 'w', newline='') as f:
+                data = self.output_data(**kwargs)
+                c = csv.DictWriter(f, data.field_list)
+                c.writeheader()
+                c.writerows(data.records)
+            return self
+        except:
+            return self


### PR DESCRIPTION
Adds a ParserCollection class to the doc_parser module which greatly simplifies outputting data from multiple docs into csv files, as well as generic dict output which can be used to create other output formats.